### PR TITLE
summary plots

### DIFF
--- a/data-products/pydarn_generate_summary_plots.py
+++ b/data-products/pydarn_generate_summary_plots.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2019 SuperDARN Canada, University of Saskatchewan
+# Author: Marina Schmidt
+#
+# Description: This script is used to generate summary plots for all
+#              SuperDARN radars and for each beam for a given date
+from glob import glob
+import pydarn
+import matplotlib.pyplot as plt
+from collections import deque
+import sys
+import bz2
+import warnings
+import os
+
+
+def read_files(date, radar, data_path):
+    '''
+    reads multiple compressed 2-hour fitacf files
+    for the data and the radar
+
+    :param: date - string format of yyyymmdd
+    :param: radar - 3 letter radar abbreviation
+    :param: data_path - absolute folder path to fitacf files
+
+    :post: finds all fitacf files using glob for the given data
+        and radar abbreviation then sorts the list. This ensures the
+        times in the filenames are in order. Concatenates the data
+        together.
+
+    :return: data list of all records from the files read in
+    '''
+    year = date[0:4]
+    month = date[4:6]
+    data = deque()
+
+    # get all fitacf files for the given data and radar
+    fitacf_files = glob('{path}/{date}*{radar}*.fitacf.bz2'.format(path=data_path,date=date, radar=radar,year=year,month=month))
+
+    # check if there was any files obtained
+    if fitacf_files == []:
+        raise Exception('No data for radar {}'.format(radar))
+
+    # sort the files to ensure we are concatenating the records in order
+    fitacf_files.sort()
+
+    # sanity printing
+    print("Reading in {radar} for {date} ...".format(radar=radar, date=date))
+    # read in the compressed fitacf files using pyDARN
+    for fitacf_file in fitacf_files:
+        with bz2.open(fitacf_file) as fp:
+            fitacf_stream = fp.read()
+
+        reader = pydarn.SDarnRead(fitacf_stream, True)
+        records = reader.read_fitacf()
+        data += records
+    print("Reading complete...")
+    return data
+
+
+def plot_files(data, date, radar, plot_path):
+    """
+    Plots each beam for the data from read_files
+    into a summary plot and
+    saves the plot as a png with the name:
+        pydarn_<yyyymmdd>_<radar abbrev>.<if there is slice/channle>_bm<beam number>.png
+
+    :param: data - list of records returned from read_files
+    :param: date - string yyyymm for the plots filename
+    :param: radar - 3 letter radar abbreviation for the plots filename
+
+    :post: creates a directory to save files in if not created. Creates
+           a png per beam for that radar on the given date.
+    """
+    year=date[0:4]
+    month=date[4:6]
+
+    # makes a directory to save files in if it doesn't exist
+    os.makedirs("{}/".format(plot_path), exist_ok=True)
+
+    # get number of beams to iteratre over
+    beams = pydarn.SuperDARNRadars.radars[data[0]['stid']].hardware_info.beams
+    filename = ''
+    for beam in range(0, beams):
+        try:
+            # summary plots raise warnings on resolution
+            # size, this is annoying so lets catch them
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                pydarn.RTP.plot_summary(data, beam_num=beam)
+            filename = '{plot_path}/pydarn_{date}_{radar}_bm{beam}.png'\
+                    ''.format(plot_path=plot_path, year=year, month=month,
+                              date=date, radar=radar, beam=beam)
+            plt.savefig(filename)
+            plt.close()
+            print("Saved {} Summary plots to {} ...".format(radar, filename))
+        # pyDARN will raise an error if no data is found for
+        # that beam. Not all beams are used on all radars
+        # especially during special modes
+        except pydarn.rtp_exceptions.RTPNoDataFoundError:
+            plt.close()
+            continue
+        # TODO: check what may raise this error?
+        except pydarn.rtp_exceptions.RTPUnknownParameterError:
+            plt.close()
+            continue
+        # Any other errors needs to be documented
+        except Exception as err:
+            print("Error: {}".format(err))
+            plt.close()
+
+# check number of arguements
+# if not print usage message
+if len(sys.argv) is not 5:
+    print("Must supply one command line arguement")
+    print("Example: python3 pydarn_generate_summary_plot.py 20190102 sas /data/fitacf_30 /plot/path/")
+    exit(1)
+
+date = sys.argv[1]
+radar = sys.argv[2]
+data_path = sys.argv[3]
+plot_path = sys.argv[4]
+print("starting")
+try:
+    print("reading "+str(date))
+    data = read_files(date, radar, data_path)
+    print("plotting")
+    plot_files(data, date, radar, plot_path)
+    # to be memory efficient
+    del data
+except Exception as err:
+        print("Error: {}".format(err))
+        exit(-1)
+
+exit(0)
+

--- a/data-products/pydarn_generate_summary_plots.py
+++ b/data-products/pydarn_generate_summary_plots.py
@@ -108,7 +108,7 @@ def plot_files(data, date, radar, plot_path):
             print("Error: {}".format(err))
             plt.close()
 
-# check number of arguements
+# check number of arguments
 # if not print usage message
 if len(sys.argv) is not 5:
     print("Must supply one command line arguement")
@@ -132,4 +132,3 @@ except Exception as err:
         exit(-1)
 
 exit(0)
-

--- a/data-products/run_summary_plot_generation.sh
+++ b/data-products/run_summary_plot_generation.sh
@@ -55,7 +55,6 @@ mkdir -p ${TMPSUMMARYDIR}
 #      that don't have a matching summary plot 
 need_to_generate=$(sort <(find ${SUMMARYDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed 's/pydarn_\(.*\)_\(.*\)_.*/\1 \2/' | sort | uniq) <(find ${FITACFDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed -e 's/\([0-9]\+\)\.[0-9]\+\.[0-9]\+\.\([a-z]\+.*\)\..*/\1 \2/' | sort | uniq) | uniq -u)
 
-echo ${need_to_generate}
 # commented out as it is needed for job submission in cedar 
 #/opt/software/slurm/bin/srun /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/bin/parallel --joblog /home/mschmidt/logs/summary_logs.log -j$(nproc) --max-args=2 python3 pydarn_generate_summary_plots.py {} ${FITACFDIR} ::: ${need_to_generate}
 
@@ -65,11 +64,13 @@ parallel -j${PROC} --max-args=2 python3 pydarn_generate_summary_plots.py {} ${FI
 #chgrp -R rpp-kam136 ${SUMMARYDIR}
 #chmod -R 664 ${SUMMARYDIR} 
 
-# see comment above, same command but now with borealis fitacf data
-need_to_generate=$(sort <(find ${SUMMARYDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed 's/pydarn_\(.*\)_\(.*\)_.*/\1 \2/' | sort | uniq) <(find ${BOREALISFITACFDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed -e 's/\([0-9]\+\)\.[0-9]\+\.[0-9]\+\.\([a-z]\+.*\)\..*/\1 \2/' | sort | uniq) | uniq -u)
-parallel -j${PROC} --max-args=2 python3 pydarn_generate_summary_plots.py {} ${BOREALISFITACFDIR} ${TMPSUMMARYDIR} ::: ${need_to_generate}
+# needed for cedar as borealis fitacf and ROS fitacf are seperate currently. This will be removed in the future 
+# when borealis data is allowed to be distributed
 
-echo ${need_to_generate}
+#need_to_generate=$(sort <(find ${SUMMARYDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed 's/pydarn_\(.*\)_\(.*\)_.*/\1 \2/' | sort | uniq) <(find ${BOREALISFITACFDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed -e 's/\([0-9]\+\)\.[0-9]\+\.[0-9]\+\.\([a-z]\+.*\)\..*/\1 \2/' | sort | uniq) | uniq -u)
+#parallel -j${PROC} --max-args=2 python3 pydarn_generate_summary_plots.py {} ${BOREALISFITACFDIR} ${TMPSUMMARYDIR} ::: ${need_to_generate}
+#
+#echo ${need_to_generate}
 # cedar code
 #/opt/software/slurm/bin/srun /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/bin/parallel --joblog /home/mschmidt/logs/summary_logs.log -j$(nproc) --max-args=2 python3 pydarn_generate_summary_plots.py {} ${BOREALISFITACFDIR} ::: ${need_to_generate}
 #mv -v ${TMPSUMMARYDIR}/*.png ${BOREALISSUMMARYPLOTSDIR}/

--- a/data-products/run_summary_plot_generation.sh
+++ b/data-products/run_summary_plot_generation.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Copyrght (C) SuperDARN Canada, University of Saskatchewan 
+# Author(s): Marina Schmidt 
+#
+# Description: finds which fitacf files does not have a corresponding 
+# summary plot and creates a list. Then the list is used in parallel 
+# to generate summary plots. 
+#
+# Param: Normally date and year are passed in on cedar but for chapman 
+#        we get the current month and year
+#        On chapman we will pass in the number of processors to use, cedar we use nproc 
+#        as the number of processes are set in the job submission. 
+# Post: temprorary summary plot folder is created for generating summary plots
+#       
+
+PROC=$1
+if [[ ${PROC} -eq 0 ]]
+then
+    PROC=1 # default will be one to be safe
+fi
+
+YEAR=$(date +%Y)
+MONTH=$(date +%m)
+# since this script will run at the beginning of each day, 
+# firsts of the year/month we need to go back to get the 
+# previous months data as we won't have data for the firsts 
+# yet. 
+if [[ $(date +%d) -eq 1 ]]
+then
+    MONTH=$(date --date='-1 month' +%m) # gets the previous month
+    YEAR=$(date --date='-1 month' +%Y) # gets the previous year
+fi
+
+# setup directory structure these are not parameters 
+# because of how cedar setup jobs 
+# summary plot directories
+TMPSUMMARYDIR=/home/superdarn/tmp_summary/${YEAR}/${MONTH}/
+SUMMARYDIR=/sddata/summary_plots/${YEAR}/${MONTH}/
+
+# fitacf dirs, need a sepparate one for borealis 
+FITACFDIR=/sddata/fitacf_30/${YEAR}/${MONTH}/
+BOREALISFITACFDIR=/sddata/borealis_fitacf_30/${YEAR}/${MONTH}
+
+mkdir -p ${TMPSUMMARYDIR}
+
+# This long command does the following: 
+#   1. find all summary plots 
+#      i) remove everything except <yyyymmdd>_<radar><slice/channel> in the filename
+#      ii) pipe to sort and uniq
+#   2. concatenate that with find of all fitacf files
+#      i) remove everything in the filename except <yyyymmdd>_<radar><slice/channel>
+#      ii) pipe to sort and uniq - uniq is needed due files being 2-hour files
+#   3. sort outputs from 1. and 2. - this should put all duplicates together
+#   4. pipe to uniq -u - this removes all non unique lines leaving the dates and radars 
+#      that don't have a matching summary plot 
+need_to_generate=$(sort <(find ${SUMMARYDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed 's/pydarn_\(.*\)_\(.*\)_.*/\1 \2/' | sort | uniq) <(find ${FITACFDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed -e 's/\([0-9]\+\)\.[0-9]\+\.[0-9]\+\.\([a-z]\+.*\)\..*/\1 \2/' | sort | uniq) | uniq -u)
+
+echo ${need_to_generate}
+# commented out as it is needed for job submission in cedar 
+#/opt/software/slurm/bin/srun /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/bin/parallel --joblog /home/mschmidt/logs/summary_logs.log -j$(nproc) --max-args=2 python3 pydarn_generate_summary_plots.py {} ${FITACFDIR} ::: ${need_to_generate}
+
+parallel -j${PROC} --max-args=2 python3 pydarn_generate_summary_plots.py {} ${FITACFDIR} ${TMPSUMMARYDIR} ::: ${need_to_generate}
+# again needed for cedar
+#mv -v ${TMPSUMMARYDIR}/*.png ${SUMMARYDIR}/
+#chgrp -R rpp-kam136 ${SUMMARYDIR}
+#chmod -R 664 ${SUMMARYDIR} 
+
+# see comment above, same command but now with borealis fitacf data
+need_to_generate=$(sort <(find ${SUMMARYDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed 's/pydarn_\(.*\)_\(.*\)_.*/\1 \2/' | sort | uniq) <(find ${BOREALISFITACFDIR} -type f -exec bash -c 'basename "${0%.*}"' {} \; | sed -e 's/\([0-9]\+\)\.[0-9]\+\.[0-9]\+\.\([a-z]\+.*\)\..*/\1 \2/' | sort | uniq) | uniq -u)
+parallel -j${PROC} --max-args=2 python3 pydarn_generate_summary_plots.py {} ${BOREALISFITACFDIR} ${TMPSUMMARYDIR} ::: ${need_to_generate}
+
+echo ${need_to_generate}
+# cedar code
+#/opt/software/slurm/bin/srun /cvmfs/soft.computecanada.ca/nix/var/nix/profiles/16.09/bin/parallel --joblog /home/mschmidt/logs/summary_logs.log -j$(nproc) --max-args=2 python3 pydarn_generate_summary_plots.py {} ${BOREALISFITACFDIR} ::: ${need_to_generate}
+#mv -v ${TMPSUMMARYDIR}/*.png ${BOREALISSUMMARYPLOTSDIR}/
+#chgrp -R rpp-kam136 ${BOREALISSUMMARYPLOTSDIR}
+#chmod -R 664 ${BOREALISSUMMARYPLOTSDIR}
+
+# since chapman doesn't have write permissions to the data nas we need to rsync the files over to mrcopy
+# the chmod command sets the permissions of directories as 755 and files 644
+rsync -azvh --chown=mrcopy:users --chmod=Du=rwx,Dg=rx,Do=rx,Fu=rw,Fg=r,Fo=r ${TMPSUMMARYDIR} mrcopy@sdcopy:/sddata/summary_plots/${YEAR}/${MONTH}/
+
+exit 0
+


### PR DESCRIPTION
A new folder section focused on data product generation. 
This PR focuses on the summary plot generation for missing summer plots for existing fitacf files. 

Due to half of the workflow being on cedar and now the other half being done on Chapman. This script focuses on running on the Chapman server. However, I use this same code for cedar and want to keep the commented out code for cedar in there for when I might have to do mass backlog checks for summary plots. 

Testing - used it on cedar for months now and running on Chapman. 

Requirements - use the GNU parallel, so log files are challenging; however, it is parallel for fast production of plots. 