### PR TITLE
Fix for Borealis computer rsyncing data to the NAS regularly. 

### DIFF
--- a/borealis/rsync_to_nas.sh
+++ b/borealis/rsync_to_nas.sh
@@ -40,7 +40,7 @@ then
 	exit
 fi
 
-FILES=`find ${SOURCE} \( -name '*rawacf.hdf5.site' -o -name '*bfiq.hdf5.*' -o -name '*antennas_iq.hdf5*' \) -cmin +${CUR_FILE_THRESHOLD_MINUTES} -printf '%p\n'`
+FILES=`find ${SOURCE} \( -name '*rawacf.hdf5.*' -o -name '*bfiq.hdf5.*' -o -name '*antennas_iq.hdf5.*' \) -cmin +${CUR_FILE_THRESHOLD_MINUTES} -printf '%p\n'`
 echo $FILES
 for file in $FILES
 do


### PR DESCRIPTION
Without the period, the regex finds any antennas_iq file ending in hdf5, or hdf5.site. All temp files end in .hdf5 only, so this script was finding and transferring temp files that it shouldn't have.