### PR TITLE
Moving from .bashrc to .profile

### DIFF
--- a/borealis/rsync_to_nas
+++ b/borealis/rsync_to_nas
@@ -36,7 +36,6 @@
 
 ###################################################################################################
 
-source "${HOME}/.profile"	# Get BOREALISPATH and SITE_LINUX
 source "${HOME}/data_flow/config.sh"  # Load common data flow variables
 source "${HOME}/data_flow/library/data_flow_functions.sh"  # Load in function library
 

--- a/config.sh
+++ b/config.sh
@@ -25,7 +25,7 @@ readonly ANTENNAS_IQ_SITES=("sas" "pgr" "inv" "cly" "rkn")
 
 # Special case sites. If a site is specified here, the data flow will be slightly altered to 
 # accomodate the site
-readonly LOW_MEMORY_SITES=("pgr" "inv" "cly" "rkn")
+readonly LOW_MEMORY_SITES=("pgr" "inv" "cly" "rkn" "sas")
 readonly LOW_BANDWIDTH_SITES=("cly" "rkn")
 
 ###################################################################################################

--- a/inotify_daemons/borealis.daemon
+++ b/inotify_daemons/borealis.daemon
@@ -17,6 +17,8 @@
 
 ###################################################################################################
 
+source "${HOME}/.profile"  # Daemons don't automatically load environment variables
+
 readonly WATCH_DIR="/data/borealis_data"
 
 script_name=$(echo $(basename $0) | cut --fields 1 --delimiter '.')

--- a/inotify_daemons/borealis.daemon
+++ b/inotify_daemons/borealis.daemon
@@ -6,6 +6,7 @@
 #
 # Dependencies:
 #	- inotifywait (installed by zypper in inotify-tools)
+#   - SITE_LINUX set as environment variable in $HOME/.profile
 #
 # Triggers rsync_to_nas when 2-hour set of Borealis files finish writing
 #
@@ -15,8 +16,6 @@
 # after Borealis finishes writing the 2-hour file
 
 ###################################################################################################
-
-source "${HOME}/.profile"	# Get SITE_LINUX
 
 readonly WATCH_DIR="/data/borealis_data"
 

--- a/inotify_daemons/site-linux.daemon
+++ b/inotify_daemons/site-linux.daemon
@@ -12,8 +12,6 @@
 
 ###################################################################################################
 
-source "${HOME}/.bashrc" # source the RADARID and SDCOPY
-
 readonly WATCH_DIR="${HOME}/data_flow/.inotify_watchdir"
 mkdir --parents $WATCH_DIR
 

--- a/inotify_daemons/site-linux.daemon
+++ b/inotify_daemons/site-linux.daemon
@@ -7,10 +7,13 @@
 #
 # Dependencies:
 #	- inotifywait (installed by zypper in inotify-tools)
+#   - SDCOPY set as environment variables in ${HOME}/.profile
 #
 # Triggers from flag sent by Borealis computer inotify daemon when rsync_to_nas finishes
 
 ###################################################################################################
+
+source "${HOME}/.profile"  # Daemons don't automatically load environment variables
 
 readonly WATCH_DIR="${HOME}/data_flow/.inotify_watchdir"
 mkdir --parents $WATCH_DIR

--- a/site-linux/antennas_iq_backlog
+++ b/site-linux/antennas_iq_backlog
@@ -10,11 +10,10 @@
 #
 # Dependencies:
 #	- pydarnio installed in a virtualenv at $HOME/pydarnio-env
-# 	- RADARNAME and RADARID set as environment variables in $HOME/.bashrc
+# 	- RADARNAME and RADARID set as environment variables in $HOME/.profile
 
 ###################################################################################################
 
-source "${HOME}/.bashrc"    # source the RADARID, SDCOPY and other things
 source "${HOME}/data_flow/config.sh"  # Load common data flow variables
 source "${HOME}/data_flow/library/data_flow_functions.sh" # Load in function library
 source "${HOME}/pydarnio-env/bin/activate"

--- a/site-linux/convert_and_restructure
+++ b/site-linux/convert_and_restructure
@@ -2,7 +2,7 @@
 # Copyright 2019 SuperDARN Canada, University of Saskatchewan
 # Author: Marci Detwiller
 #
-# Last Edited: October 2022 by Theo Kolkman
+# Major revision: October 2022 by Theo Kolkman
 # Refactored for inotify usage
 #
 # A script that uses pydarnio to convert Borealis files to SuperDARN DMap files as well as 
@@ -14,7 +14,7 @@
 #
 # Dependencies:
 #	- pydarnio installed in a virtualenv at $HOME/pydarnio-env
-# 	- RADARNAME and RADARID set as environment variables in $HOME/.bashrc
+# 	- RADARID set as environment variables in $HOME/.profile
 #	- ssh link established between Site-Linux and TELEMETRY computers
 #
 # This script should be run via an inotify daemon that triggers when the previous data flow script
@@ -22,7 +22,6 @@
 
 ###################################################################################################
 
-source "${HOME}/.bashrc"    # source the RADARID, SDCOPY and other things
 source "${HOME}/data_flow/config.sh"  # Load common data flow variables
 source "${HOME}/data_flow/library/data_flow_functions.sh" # Load in function library
 source "${HOME}/pydarnio-env/bin/activate"

--- a/site-linux/rsync_to_campus
+++ b/site-linux/rsync_to_campus
@@ -2,7 +2,7 @@
 # Copyright 2019 SuperDARN Canada, University of Saskatchewan
 # Author: Dieter Andre
 #
-# Last Edited: October 2022 by Theo Kolkman
+# Major revision: October 2022 by Theo Kolkman
 # Refactored for inotify usage
 #
 # A singleton script to transfer rawacf dmap and hdf5 files from site NAS to superdarn-cssdp on 
@@ -12,7 +12,7 @@
 #	1. Remove RADARID for the specified site from NAS_SITES in config.sh
 #
 # Dependencies:
-# 	- RADARID and SDCOPY set as environment variables in ${HOME}/.bashrc
+# 	- RADARID and SDCOPY set as environment variables in ${HOME}/.profile
 #	- ssh link established between Site-Linux and SDCOPY computers
 #	- ssh link established between Site-Linux and TELEMETRY computers
 #
@@ -21,7 +21,6 @@
 
 ###################################################################################################
 
-source "${HOME}/.bashrc" # source the RADARID, SDCOPY and other things
 source "${HOME}/data_flow/config.sh"  # Load common data flow variables
 source "${HOME}/data_flow/library/data_flow_functions.sh" # Load dataflow functions
 


### PR DESCRIPTION
### Summary
To facilitate site computers moving all environment variables to `.profile`, some data flow scripts have to be modified. 

Discussion as to why this move is being made is available here: https://trello.com/c/dXmop5ZA/514-move-all-environment-variables-from-bashrc-to-profile

### Testing
Currently testing on all Saskatoon computers, after modified their respective `.profile` and `.bashrc` files.