### PR TITLE
Fix an issue with boolean fields stemming from deepdish.

### DIFF
--- a/borealis/rsync_to_nas
+++ b/borealis/rsync_to_nas
@@ -124,6 +124,10 @@ fi
 # Transfer files
 for file in $files
 do
+  # Ensure that the file has all group permissions enabled (read/write/execute)
+  printf "\nChanging permissions to 755 for $file\n"
+  chmod 775 $file
+
 	printf "\nTransferring: $file\n"
 	if [[ " ${NAS_SITES[*]} " =~ " ${RADAR_ID} " ]]; then
 		# rsync file to NAS

--- a/site-linux/borealis_convert_file.py
+++ b/site-linux/borealis_convert_file.py
@@ -191,7 +191,7 @@ def borealis_site_to_array_file(filename, borealis_filetype, array_filename, low
     if low_memory:
         # Specify zlib so compression is the same as BorealisWrite
         borealis_writer = BorealisRestructure(filename, array_filename, borealis_filetype, 
-                                              outfile_structure='array', hdf5_compression='zlib')
+                                              outfile_structure='array', hdf5_compression='gzip')
         return borealis_writer.outfile_name
 
     else: 
@@ -199,7 +199,7 @@ def borealis_site_to_array_file(filename, borealis_filetype, array_filename, low
                                     borealis_file_structure='site')
         arrays = borealis_reader.arrays # restructures the input records to arrays
         borealis_writer = BorealisWrite(array_filename, arrays, borealis_filetype,
-                                        borealis_file_structure='array')
+                                        borealis_file_structure='array', hdf5_compression='gzip')
         return borealis_writer.filename # overwrite to as generated
 
 

--- a/site-linux/convert_and_restructure
+++ b/site-linux/convert_and_restructure
@@ -134,10 +134,20 @@ for f in $RAWACF_CONVERT_FILES; do
                 ordinal_id="$(($slice_id + 97))"
                 file_character=$(chr $ordinal_id)
                 dmap_file="${dmap_file_wo_slice_id}${file_character}.rawacf.bz2"
+
+                # First ensure the permissions are read/write/execute for the group
+                printf "chmod 775 ${dmap_file}\n"
+                chmod 775 ${dmap_file}
+
                 mv --verbose $dmap_file $RAWACF_DMAP_DEST
             fi
 
             array_file="${f%.site}"
+
+            # First ensure the permissions are read/write/execute for the group
+            printf "chmod 775 ${array_file}\n"
+            chmod 775 ${array_file}
+
             mv --verbose $array_file $RAWACF_ARRAY_DEST
             rm --verbose $f
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
@@ -175,6 +185,11 @@ for f in $BFIQ_CONVERT_FILES; do
         if [[ $ret -eq 0 ]]; then
             # Only converting array file
             array_file="${f%.site}"
+
+            # First ensure the permissions are read/write/execute for the group
+            printf "chmod 775 ${array_file}\n"
+            chmod 775 ${array_file}
+
             mv --verbose $array_file $BFIQ_ARRAY_DEST
             rm --verbose $f
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
@@ -220,6 +235,11 @@ for f in $ANTENNAS_IQ_CONVERT_FILES; do
         if [ $ret -eq 0 ]; then
             # then remove source site file.
             array_file="${f%.site}"
+
+            # First ensure the permissions are read/write/execute for the group
+            printf "chmod 775 ${array_file}\n"
+            chmod 775 ${array_file}
+            
             mv --verbose $array_file $ANTENNAS_IQ_ARRAY_DEST
             rm --verbose $f
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE

--- a/site-linux/remove_record.py
+++ b/site-linux/remove_record.py
@@ -53,7 +53,7 @@ def find_borealis_sequence_errors(filename):
         records = sorted(list(f.keys()))
         for record_name in records:
             data = f[record_name]
-            if data['sqn_timestamps'].shape[0] != data['num_sequences']:
+            if data['sqn_timestamps'].shape[0] != data.attrs['num_sequences']:
                 del f[record_name]
                 print(f'Deleted: {record_name}')
 

--- a/site-linux/remove_record.py
+++ b/site-linux/remove_record.py
@@ -13,8 +13,8 @@ If a record name is provided, only the given record will be removed.
 
 """
 import argparse
-import deepdish
 import h5py
+
 
 def usage_msg():
     """
@@ -40,30 +40,28 @@ def usage_msg():
 def remove_records_parser():
     parser = argparse.ArgumentParser(usage=usage_msg())
     parser.add_argument("borealis_site_file", help="Path to the array file that needs correction.")
-    parser.add_argument("--record_name", default='', help="Group name in the hdf5 file to remove (Borealis record name).")
+    # parser.add_argument("--record_name", default='', help="Group name in the hdf5 file to remove (Borealis record name).")
     return parser
+
 
 def find_borealis_sequence_errors(filename):
     """
     Removes any records in the file where the shape of the sequences data 
     is not the correct size for the given num_sequences. 
     """
-    records = sorted(deepdish.io.load(filename).keys())
-    for record_name in records:
-        groupname = '/' + record_name
-        data = deepdish.io.load(filename,group=groupname)
-        if data['sqn_timestamps'].shape[0]!=data['num_sequences']:
-            remove_record(filename, groupname)
+    with h5py.File(filename, 'a') as f:
+        records = sorted(list(f.keys()))
+        for record_name in records:
+            data = f[record_name]
+            if data['sqn_timestamps'].shape[0] != data['num_sequences']:
+                del f[record_name]
+                print(f'Deleted: {record_name}')
 
-def remove_record(file_1, groupname):
-    with h5py.File(file_1,  "a") as f:
-        del f[groupname]
-        print('Deleted: ', groupname)
 
 if __name__ == '__main__':
     parser = remove_records_parser()
     args = parser.parse_args()
-    if args.record_name:
-        remove_record(args.borealis_site_file, args.record_name)
-    else:
-        find_borealis_sequence_errors(args.borealis_site_file)
+    # if args.record_name:
+    #     remove_record(args.borealis_site_file, args.record_name)
+    # else:
+    find_borealis_sequence_errors(args.borealis_site_file)


### PR DESCRIPTION
I'm pretty sure the following symptom is due to deepdish not being maintained:

```
python3 remove_record.py 20230811.0800.00.cly.0.rawacf.hdf5.site
/home/transfer/pydarnio-env/lib64/python3.9/site-packages/tables/attributeset.py:291: DataTypeWarning: Unsupported type for attribute 'gps_locked' in node '1691740860044'. Offending HDF5 class: 8
  value = self._g_getattr(self._v_node, name)
/home/transfer/pydarnio-env/lib64/python3.9/site-packages/tables/attributeset.py:291: DataTypeWarning: Unsupported type for attribute 'scan_start_marker' in node '1691740860044'. Offending HDF5 class: 8
  value = self._g_getattr(self._v_node, name)
  ```

To fix this, I've switched to using h5py solely, and dropping the deepdish dependency altogether.