### PR TITLE
Added Slack webhook calls

### DIFF
--- a/campus/convert_on_campus
+++ b/campus/convert_on_campus
@@ -103,7 +103,12 @@ if [[ " ${CONVERT_ON_CAMPUS_SITES[*]} " =~ " ${RADAR_ID} " ]]; then
             mv --verbose $f $DEST
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
         else
-            printf "File failed to convert: ${f}\n" | tee --append $SUMMARY_FILE
+            msg="File failed to convert to dmap: ${f}\n"
+            printf "msg" | tee --append $SUMMARY_FILE
+
+            message="$(date +'%Y%m%d %H:%M:%S')   campus ${RADAR_ID} - ${msg}"
+            alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
+
             mv --verbose $f $PROBLEM_FILES_DEST
         fi
     done

--- a/campus/convert_on_campus
+++ b/campus/convert_on_campus
@@ -103,10 +103,10 @@ if [[ " ${CONVERT_ON_CAMPUS_SITES[*]} " =~ " ${RADAR_ID} " ]]; then
             mv --verbose $f $DEST
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
         else
-            msg="File failed to convert to dmap: ${f}\n"
-            printf "msg" | tee --append $SUMMARY_FILE
+            error="File failed to convert to dmap: ${f}\n"
+            printf "${error}" | tee --append $SUMMARY_FILE
 
-            message="$(date +'%Y%m%d %H:%M:%S')   campus ${RADAR_ID} - ${msg}"
+            message="$(date +'%Y%m%d %H:%M:%S')   convert_on_campus ${RADAR_ID} - ${error}"
             alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
 
             mv --verbose $f $PROBLEM_FILES_DEST

--- a/library/data_flow_functions.sh
+++ b/library/data_flow_functions.sh
@@ -144,7 +144,7 @@ verify_transfer () {
 }
 
 ###################################################################################################
-# Sends an alert to a slack channel - generally data-flow-alerts
+# Sends an alert to a slack channel - generally the #data-flow-alerts channel
 #
 # Takes in a message to send to slack and a slack webhook and attempts to send that message to
 # the associated slack channel through the Borealis Alerts incoming webhooks app. The message
@@ -161,7 +161,7 @@ alert_slack() {
 
   NOW=$(date +'%Y%m%d %H:%M:%S')
   if [[ -z ${message} ]]; then
-    echo "${NOW} dataflow slack message error: Emtpy message attempted to be sent." | tee -a "${LOGFILE}"
+    echo "${NOW} dataflow slack message error: Empty message attempted to be sent." | tee -a "${LOGFILE}"
   elif [[ -z ${webhook} ]]; then
     echo "${NOW} dataflow webhook error: No webhook was found. Attempted message was ${message}" | tee -a "${LOGFILE}"
   fi

--- a/library/data_flow_functions.sh
+++ b/library/data_flow_functions.sh
@@ -1,5 +1,5 @@
 # Copyright 2022 SuperDARN Canada, University of Saskatchewan
-# Author: Theodore Kolkman
+# Author: Theodore Kolkman, Draven Galeschuk
 #
 # This file contains functions used by various data flow scripts
 # Functions have been moved here from within other scripts to clean up code
@@ -141,4 +141,34 @@ verify_transfer () {
 	# Check md5sum of destination file is same as source
 	md5sum --check --status $HOME/tmp.md5
 	return $?
+}
+
+###################################################################################################
+# Sends an alert to a slack channel - generally data-flow-alerts
+#
+# Takes in a message to send to slack and a slack webhook and attempts to send that message to
+# the associated slack channel through the Borealis Alerts incoming webhooks app. The message
+# should contain useful information such as: timestamp on computer, file/files affected,
+# error message or description of problem, device error occurred on.
+#
+# Argument 1: message to send
+# Argument 2: slack webhook. likely loaded into the script calling this function from .profile
+###################################################################################################
+alert_slack() {
+  message=$1
+  webhook=$2
+  LOGFILE="${HOME}/logs/slack_dataflow_notif.log"
+
+  NOW=$(date +'%Y%m%d %H:%M:%S')
+  if [[ -z ${message} ]]; then
+    echo "${NOW} dataflow slack message error: Emtpy message attempted to be sent." | tee -a "${LOGFILE}"
+  elif [[ -z ${webhook} ]]; then
+    echo "${NOW} dataflow webhook error: No webhook was found. Attempted message was ${message}" | tee -a "${LOGFILE}"
+  fi
+
+  curl --silent --header "Content-type: application/json" --data "{'text':'${message}'}" "${webhook}"
+  result=$?
+  if [[ ${result} -ne 0 ]]; then
+    echo "${NOW} attempt to curl to webhook ${webhook} failed with error: ${result} (see https://curl.se/libcurl/c/libcurl-errors.html)" | tee -a "${LOGFILE}"
+  fi
 }

--- a/site-linux/convert_and_restructure
+++ b/site-linux/convert_and_restructure
@@ -108,10 +108,10 @@ for f in $RAWACF_CONVERT_FILES; do
         printf "python3 remove_record.py $(basename ${f})\n"
         output=$(python3 ${HOME}/data_flow/site-linux/remove_record.py ${f})
         if [[ $? -ne 0 ]]; then
-            msg="remove_record.py failed: ${f}\n"
-            printf ${msg} | tee --append $SUMMARY_FILE
+            error="remove_record.py failed: ${f}\n"
+            printf ${error} | tee --append $SUMMARY_FILE
 
-            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${msg}"
+            message="$(date +'%Y%m%d %H:%M:%S')   convert_and_restructure ${RADAR_ID} - ${error}"
             alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
 
             mv --verbose $f $PROBLEM_FILES_DEST
@@ -150,10 +150,10 @@ for f in $RAWACF_CONVERT_FILES; do
             rm --verbose $f
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
         else
-            msg="File failed to convert from rawacf to dmap: ${f}\n"
-            printf "${msg}" | tee --append $SUMMARY_FILE
+            error="File failed to convert from rawacf from site to array and/or dmap: ${f}\n"
+            printf "${error}" | tee --append $SUMMARY_FILE
 
-            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${msg}"
+            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${error}"
             alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
 
             mv --verbose $f $PROBLEM_FILES_DEST
@@ -196,10 +196,10 @@ for f in $BFIQ_CONVERT_FILES; do
             rm --verbose $f
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
         else
-            msg="File failed to convert from bfi1 to array: ${f}\n"
-            printf "" | tee --append $SUMMARY_FILE
+            error="File failed to convert from bfiq from site to array: ${f}\n"
+            printf "${error}" | tee --append $SUMMARY_FILE
 
-            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${msg}"
+            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${error}"
             alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
 
             mv --verbose $f $PROBLEM_FILES_DEST
@@ -250,10 +250,10 @@ for f in $ANTENNAS_IQ_CONVERT_FILES; do
             rm --verbose $f
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
         else
-            msg="File failed to convert from iq to array: ${f}\n"
-            printf "${msg}" | tee --append $SUMMARY_FILE
+            error="File failed to convert from antennas_iq from site to array: ${f}\n"
+            printf "${error}" | tee --append $SUMMARY_FILE
 
-            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${msg}"
+            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${error}"
             alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
 
             mv --verbose $f $PROBLEM_FILES_DEST

--- a/site-linux/convert_and_restructure
+++ b/site-linux/convert_and_restructure
@@ -107,8 +107,13 @@ for f in $RAWACF_CONVERT_FILES; do
         
         printf "python3 remove_record.py $(basename ${f})\n"
         output=$(python3 ${HOME}/data_flow/site-linux/remove_record.py ${f})
-        if [[ $? -ne 0 ]]; then 
-            printf "remove_record.py failed: ${f}\n" | tee --append $SUMMARY_FILE
+        if [[ $? -ne 0 ]]; then
+            msg="remove_record.py failed: ${f}\n"
+            printf ${msg} | tee --append $SUMMARY_FILE
+
+            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${msg}"
+            alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
+
             mv --verbose $f $PROBLEM_FILES_DEST
             continue
         elif [[ -n "$output" ]]; then
@@ -145,7 +150,12 @@ for f in $RAWACF_CONVERT_FILES; do
             rm --verbose $f
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
         else
-            printf "File failed to convert: ${f}\n" | tee --append $SUMMARY_FILE
+            msg="File failed to convert from rawacf to dmap: ${f}\n"
+            printf "${msg}" | tee --append $SUMMARY_FILE
+
+            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${msg}"
+            alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
+
             mv --verbose $f $PROBLEM_FILES_DEST
         fi
     else
@@ -186,7 +196,12 @@ for f in $BFIQ_CONVERT_FILES; do
             rm --verbose $f
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
         else
-            printf "File failed to convert: ${f}\n" | tee --append $SUMMARY_FILE
+            msg="File failed to convert from bfi1 to array: ${f}\n"
+            printf "" | tee --append $SUMMARY_FILE
+
+            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${msg}"
+            alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
+
             mv --verbose $f $PROBLEM_FILES_DEST
         fi
     else
@@ -235,7 +250,12 @@ for f in $ANTENNAS_IQ_CONVERT_FILES; do
             rm --verbose $f
             printf "Successfully converted: ${f}\n" | tee --append $SUMMARY_FILE
         else
-            printf "File failed to convert: ${f}\n" | tee --append $SUMMARY_FILE
+            msg="File failed to convert from iq to array: ${f}\n"
+            printf "${msg}" | tee --append $SUMMARY_FILE
+
+            message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${msg}"
+            alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"
+
             mv --verbose $f $PROBLEM_FILES_DEST
         fi
     else


### PR DESCRIPTION
Made a function for sending a message to slack and implemented it wherever there a script failed during conversion of a file in the `data_flow_functions` file.

The function can take any webhook, but the variable `SLACK_DATAFLOW_WEBHOOK` which should be defined in `.profile` for any computer running this to have the webhook pointing to Slack channel #data-flow-alerts

Some error checks were put in the slack message function, which write to `${HOME}/logs/slack_dataflow_notif.log` if there is any issues sending a message to slack (hopefully)