### PR TITLE
Irregular Timestamp Check

### DIFF
--- a/borealis/rsync_to_nas
+++ b/borealis/rsync_to_nas
@@ -1,35 +1,36 @@
 #!/bin/bash
-# Copyright 2019 SuperDARN Canada, University of Saskatchewan
-# Author: Kevin Krieger, Theodore Kolkman
+# Copyright 2019 SuperDARN Canada, University of Saskatchewan Author: Kevin Krieger, Theodore
+# Kolkman
 #
 # A singleton script to move Borealis files from the Borealis computer to the site NAS. Files are
 # copied first and removed once copy is confirmed to be successful. This script is to be run on the
 # site computer running Borealis.
 #
 # To move files to the Site-Linux computer instead of the NAS: 
-#	1. Remove the RADAR_ID of the site from NAS_SITES in config.sh
-#	2. Ensure SITE_LINUX is set correctly within $HOME/.profile
-#	3. Ensure the directory specified in the DEST variable exists on the Site-Linux computer
+#   1. Remove the RADAR_ID of the site from NAS_SITES in config.sh
+#   2. Ensure SITE_LINUX is set correctly within $HOME/.profile
+#   3. Ensure the directory specified in the DEST variable exists on the Site-Linux computer
 #
 # Dependencies:
-#	- jq (installed via zypper)
-# 	- RADAR_ID, BOREALISPATH and SITE_LINUX set as environment variables in $HOME/.profile
-#	- ssh link established between Borealis and TELEMETRY computers
+#   - jq (installed via zypper)
+#   - RADAR_ID, BOREALISPATH, SITE_LINUX, and SLACK_DATAFLOW_WEBHOOK set as environment variables in
+#     $HOME/.profile
+#   - ssh link established between Borealis and TELEMETRY computers
 #
-# This script should be run via an inotify daemon triggering whenever 2-hour Borealis site files 
+# This script should be run via an inotify daemon triggering whenever 2-hour Borealis site files
 # finish writing
 #
-# Inotify watches the directory Borealis writes to, and triggers the rsync_to_nas script only when
-# a 2-hour site file is created. Since these files are only created once, and once they're created
-# the previous 2-hour block is finished writing, the rsync_to_nas script will execute immediately 
-# after Borealis finishes writing the previous 2-hour file. To distinguish between the previous 
-# (finished writing) and current (currently writing) 2-hour file, the `find` command must be used 
-# as specified in the script below.
+# Inotify watches the directory Borealis writes to, and triggers the rsync_to_nas script only when a
+# 2-hour site file is created. Since these files are only created once, and once they're created the
+# previous 2-hour block is finished writing, the rsync_to_nas script will execute immediately after
+# Borealis finishes writing the previous 2-hour file. To distinguish between the previous (finished
+# writing) and current (currently writing) 2-hour file, the `find` command must be used as specified
+# in the script below.
 #
-# Param 1: Borealis file name that script was triggered on. This will be used to filter out the 
-#		   files currently being written to, using the timestamp in the name. File name must be of 
-#		   format YYYYMMDD.HHMM.SS.[rest of filename]. If no input is given, then script defaults 
-#		   to omitting only files written to in the last 5 minutes.
+# Param 1: Borealis file name that script was triggered on. This will be used to filter out the
+#          files currently being written to, using the timestamp in the name. File name must be of
+#          format YYYYMMDD.HHMM.SS.[rest of filename]. If no input is given, then script defaults to
+#          omitting only files written to in the last 5 minutes.
 
 ###################################################################################################
 
@@ -129,6 +130,8 @@ fi
 # Transfer files
 for file in $files
 do
+	printf "\nSynching: $file\n"
+	
 	# Ensure that the file has all group permissions enabled (read/write/execute)
 	chmod --verbose 775 $file
 
@@ -138,12 +141,16 @@ do
 	# the destination to the failed file directory.
 	check_timestamp $file
 	if [[ $? -eq 2 ]]; then 	# check_timestamp failed
-		printf "check_timestamp failed: ${file}\n" | tee --append $SUMMARY_FILE
-		SPECIFIC_DEST="$FAIL_DEST"
-	fi
-	
+		error="check_timestamp failed: ${file}\n"
+		printf "${error}" | tee --append $SUMMARY_FILE
 
-	printf "\nTransferring: $file\n"
+		message="$(date +'%Y%m%d %H:%M:%S')   ${RADAR_ID} - ${error}"
+		alert_slack "${message}" "${SLACK_DATAFLOW_WEBHOOK}"	# Send alert to Slack
+
+		SPECIFIC_DEST="$FAIL_DEST"	# Change destination
+	fi
+
+	printf "Destination: $SPECIFIC_DEST\n"
 	if [[ " ${NAS_SITES[*]} " =~ " ${RADAR_ID} " ]]; then
 		# rsync file to NAS
 		rsync -av --append-verify --timeout=180 --rsh=ssh $file $SPECIFIC_DEST

--- a/borealis/rsync_to_nas
+++ b/borealis/rsync_to_nas
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Copyright 2019 SuperDARN Canada, University of Saskatchewan Author: Kevin Krieger, Theodore
-# Kolkman
+# Copyright 2019 SuperDARN Canada, University of Saskatchewan 
+# Author: Kevin Krieger, Theodore Kolkman
 #
 # A singleton script to move Borealis files from the Borealis computer to the site NAS. Files are
 # copied first and removed once copy is confirmed to be successful. This script is to be run on the

--- a/borealis/rsync_to_nas
+++ b/borealis/rsync_to_nas
@@ -45,10 +45,13 @@ readonly SOURCE="$(cat ${BOREALISPATH}/config/${RADAR_ID}/${RADAR_ID}_config.ini
 
 # Directory the files will be transferred to
 if [[ " ${NAS_SITES[*]} " =~ " ${RADAR_ID} " ]]; then
-	readonly DEST="/borealis_nfs/borealis_data/daily/" # On NAS
+	readonly DEST="/borealis_nfs/borealis_data" # On NAS
 else
-	readonly DEST="/data/borealis_data/daily" # On Site Linux
+	readonly DEST="/data/borealis_data" # On Site Linux
 fi
+
+readonly SUCCESS_DEST="${DEST}/daily/" # All good Borealis files go here
+readonly FAIL_DEST="${DEST}/conversion_failure/" # Any files that fail checks go here
 
 # Create log file. New file created daily
 readonly LOGGING_DIR="${HOME}/logs/rsync_to_nas/$(date +%Y/%m)"
@@ -129,19 +132,30 @@ do
 	# Ensure that the file has all group permissions enabled (read/write/execute)
 	chmod --verbose 775 $file
 
+	SPECIFIC_DEST="$SUCCESS_DEST"
+
+	# Check that the timestamps and file modification times are consistent. If they aren't, change
+	# the destination to the failed file directory.
+	check_timestamp $file
+	if [[ $? -eq 2 ]]; then 	# check_timestamp failed
+		printf "check_timestamp failed: ${file}\n" | tee --append $SUMMARY_FILE
+		SPECIFIC_DEST="$FAIL_DEST"
+	fi
+	
+
 	printf "\nTransferring: $file\n"
 	if [[ " ${NAS_SITES[*]} " =~ " ${RADAR_ID} " ]]; then
 		# rsync file to NAS
-		rsync -av --append-verify --timeout=180 --rsh=ssh $file $DEST
+		rsync -av --append-verify --timeout=180 --rsh=ssh $file $SPECIFIC_DEST
 
 		# Check if transfer was okay using the md5sum program
-		verify_transfer $file "${DEST}/$(basename $file)"
+		verify_transfer $file "${SPECIFIC_DEST}/$(basename $file)"
 		return_value=$?
 	else
 		# rsync file to site computer
-		rsync -av --append-verify --timeout=180 --rsh=ssh $file $SITE_LINUX:$DEST
+		rsync -av --append-verify --timeout=180 --rsh=ssh $file $SITE_LINUX:$SPECIFIC_DEST
 
-		verify_transfer $file "${DEST}/$(basename $file)" $SITE_LINUX
+		verify_transfer $file "${SPECIFIC_DEST}/$(basename $file)" $SITE_LINUX
 		return_value=$?
 	fi
 

--- a/library/data_flow_functions.sh
+++ b/library/data_flow_functions.sh
@@ -4,7 +4,7 @@
 # This file contains functions used by various data flow scripts
 # Functions have been moved here from within other scripts to clean up code
 #
-# To use this library:  source $HOME/data_flow/lib/data_flow_functions.sh
+# To use this library:  `source $HOME/data_flow/library/data_flow_functions.sh``
 
 
 ###################################################################################################
@@ -44,7 +44,7 @@ get_dmap_name() {
 
 	array_filename=$(basename $1)
 	array_directory=$(dirname $1)
-	# Check that the filename given is a valid dmap file name
+	# Check that the filename given is a valid rawacf file name
 	if [[ ! "$array_filename" =~ ^[0-9]{8}.[0-9]{4}.[0-9]{2}.[[:lower:]]{3}.[0-9]+.rawacf.hdf5$   ]]; then
 		printf "get_dmap_name(): Invalid filename - $array_filename isn't a valid array file name\n"
 		return 1
@@ -171,4 +171,56 @@ alert_slack() {
   if [[ ${result} -ne 0 ]]; then
     echo "${NOW} attempt to curl to webhook ${webhook} failed with error: ${result} (see https://curl.se/libcurl/c/libcurl-errors.html)" | tee -a "${LOGFILE_SLACKALERT}"
   fi
+}
+
+###################################################################################################
+# Verify that the timestamp and last modification time of a Borealis file are consistent
+#
+# Compares the timestamp in a Borealis file's name (i.e. 20220617.2200.00) to the last modification
+# time of the file (found with the 'stat' command). If the difference in these times is greater
+# than a specified threshold, the function returns an error code.
+#
+# Argument 1: Path to a Borealis .site file to check.
+#
+# Returns 0: Success: difference between timestamp and modification time are consistent.
+#         1: Error: Function used incorrectly
+#         2: Failure: difference between timestamp and modification time is greater than the 
+#         specified threshold
+###################################################################################################
+check_timestamp() {
+	# Check function was called correctly
+	if [[ $# -ne 1 ]]; then
+		printf "check_timestamp(): Invalid number of arguments\n" 
+		printf "Usage: check_timestamp filename"
+		return 1
+	fi
+
+	local file=$1						# Borealis file to check
+	local filename=$(basename $file)	# The name of the file (no path)
+	local threshold=86400				# Threshold is 1 day (86400 seconds)
+
+	# Check that the filename given is a valid file name
+	if [[ ! "$filename" =~ ^[0-9]{8}\.[0-9]{4}\.[0-9]{2}\.[[:lower:]]{3}\.[0-9]+\..+\.hdf5.site$   ]]; then
+		printf "check_timestamp(): Invalid filename - $filename isn't a valid .site file name\n"
+		return 1
+	fi
+
+	# Get timestamp time in seconds since epoch from the filename timestamp. 
+	# Must replace '.' with ' ' to get a string that can be interpreted by `date` command
+	local timestamp_string=$(echo $filename | cut --fields 1-2 --delimiter '.')
+	local timestamp_time=$(date --utc --date "${timestamp_string//./ }" +%s)		
+
+	# Get file modification time in seconds since epoch	
+	local modification_time=$(stat --format=%Y "$file")
+
+	# Get time difference
+	local time_diff=$(($modification_time - $timestamp_time))
+	local absolute_diff="${time_diff#-}" # Remove '-' sign to ensure difference is positive
+	if [[ $absolute_diff -gt $threshold ]]; then
+		# File timestamp and modification time is inconsistent - return error code 2
+		return 2
+	fi
+
+	# If end of function is reached, the file timestamp and modification times are consistent.
+	return 0
 }

--- a/library/data_flow_functions.sh
+++ b/library/data_flow_functions.sh
@@ -4,7 +4,7 @@
 # This file contains functions used by various data flow scripts
 # Functions have been moved here from within other scripts to clean up code
 #
-# To use this library:  `source $HOME/data_flow/library/data_flow_functions.sh``
+# To use this library:  `source $HOME/data_flow/library/data_flow_functions.sh`
 
 
 ###################################################################################################

--- a/site-linux/convert_and_restructure
+++ b/site-linux/convert_and_restructure
@@ -13,7 +13,7 @@
 #
 # Dependencies:
 #	- pydarnio installed in a virtualenv at $HOME/pydarnio-env
-# 	- RADAR_ID set as environment variables in $HOME/.profile
+# 	- RADAR_ID and SLACK_DATAFLOW_WEBHOOK set as environment variables in $HOME/.profile
 #	- ssh link established between Site-Linux and TELEMETRY computers
 #
 # This script should be run via an inotify daemon that triggers when the previous data flow script


### PR DESCRIPTION
# Overview
Added a check to resolve https://github.com/SuperDARNCanada/data_flow/issues/41

The check compares the file timestamp with its most recent modification time, and checks that they are both within 1 day. If they aren't, the file likely has a problem.

This check is done on rsync_to_nas on the .site files right after they are produced by Borealis. If this check is done later on, files would have a chance to be modified, and this check could trigger for cases that aren't of concern.

# Testing
The timestamp check is done by a function within `data_flow_functions.sh`. This function was tested with the following inputs:
- A good rawacf file
- A rawacf file with a more recent modification time (> 1 day)
- A rawacf file with a more recent timestamp in the filename (> 1 day)

I also tested that rsync_to_nas runs correctly with the new check on my own computer.

Next step is to run at one of our sites, and make sure the data flow still works.