### PR TITLE
rsync_to_nas failing to transfer dmap files in niche case

### DIFF
--- a/borealis/rsync_to_nas
+++ b/borealis/rsync_to_nas
@@ -146,6 +146,9 @@ do
 		SPECIFIC_DEST="$RAWACF_DMAP_DEST"
 		needs_zip=1  # bzip rawacf DMAP files
 		backup=1  # backup rawacf files
+	elif [[ $file == *.rawacf.bz2 ]]; then
+		SPECIFIC_DEST="$RAWACF_DMAP_DEST"
+		backup=1  # backup rawacf files
 	elif [[ $file == *.rawacf.h5 ]]; then
 		SPECIFIC_DEST="$RAWACF_ARRAY_DEST"
 		backup=1  # backup rawacf files


### PR DESCRIPTION
At Inuvik, the file destination directory (on the NAS) apparently disconnected, causing a transfer to fail. Before this occurred, the rawacf file was compressed and given the extension `.bz2`. The next time `rsync_to_nas` ran, it failed to recognize the new file extension, so it moved the file to the `conversion_failure` directory.

This change allows `rawacf.bz2` files to transfer to the correct spot on the NAS, bypassing the compression step within `rsync_to_nas`.